### PR TITLE
eliminate warning for unused method during testing

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8,6 +8,7 @@ pub const CONTRACT_URL: &str = "...";
 #[test]
 #[should_panic]
 pub fn test_resolve_did() {
+    crate::integration_util::init_logging();
     todo!()
     // stub
 }


### PR DESCRIPTION
## What's the problem ?

Running `cargo test` generated the following warning:
```
warning: static `INIT` is never used
 --> tests/integration_util/mod.rs:6:8
  |
6 | static INIT: Once = Once::new();
  |        ^^^^
  |
  = note: `#[warn(dead_code)]` on by default

warning: function `init_logging` is never used
 --> tests/integration_util/mod.rs:8:15
  |
8 | pub(crate) fn init_logging() {
  |               ^^^^^^^^^^^^

warning: `didethresolver` (test "integration_test") generated 2 warnings
```

## Why does that happen ?

We currently have no integration tests implemented. In fact, we have a single stub called `test_resolve_did` that have a single like of code : 
```rust
todo!()
```

As a result of that, the `init_logging` and the `INIT` aren't being used.

## Solution

Modify the `test_resolve_did()` implementation, and add a call to `init_logging`. This would eliminate the warning, as the method would be called.

## Note

This PR is identical to the previous one ( https://github.com/xmtp/didethresolver/pull/19 ), but made with a verified committing user.
