### PR TITLE
Make docker build fail if clippy complains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=ghcr.io/xmtp/foundry:latest /usr/local/bin/anvil /usr/local/bin/anvi
 COPY --chown=xmtp:xmtp . .
 
 RUN cargo fmt --check
-RUN cargo clippy --all-features --no-deps
+RUN cargo clippy --all-features --no-deps -- -D warnings
 RUN cargo test 
 
 CMD cargo run

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -39,7 +39,7 @@ impl Resolver {
 
     pub async fn resolve_did(&self, public_key: H160) -> Result<DidDocument> {
         let history = self.changelog(public_key).await?;
-        self.wrap_did_document(public_key, history).await?
+        self.wrap_did_document(public_key, history).await
     }
 
     async fn changelog(&self, public_key: H160) -> Result<Vec<(DIDRegistryEvents, LogMeta)>> {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -39,7 +39,7 @@ impl Resolver {
 
     pub async fn resolve_did(&self, public_key: H160) -> Result<DidDocument> {
         let history = self.changelog(public_key).await?;
-        Ok(self.wrap_did_document(public_key, history).await?)
+        self.wrap_did_document(public_key, history).await?
     }
 
     async fn changelog(&self, public_key: H160) -> Result<Vec<(DIDRegistryEvents, LogMeta)>> {

--- a/src/types/did_parser.rs
+++ b/src/types/did_parser.rs
@@ -69,7 +69,7 @@ peg::parser! {
 
         rule ethereum_address() -> AddressOrHexKey
             = "0" i("x") digits:$(hex_digit()*<40>) {
-                AddressOrHexKey::Address(Address::from_slice(&hex::decode(&digits).unwrap()))
+                AddressOrHexKey::Address(Address::from_slice(&hex::decode(digits).unwrap()))
             }
 
         rule public_key_hex() -> AddressOrHexKey

--- a/src/types/did_url.rs
+++ b/src/types/did_url.rs
@@ -70,7 +70,7 @@ pub enum ChainId {
 
 impl<'a> From<&'a str> for ChainId {
     fn from(digits: &'a str) -> ChainId {
-        let num = usize::from_str_radix(&digits, 16).expect("String must be valid Hex");
+        let num = usize::from_str_radix(digits, 16).expect("String must be valid Hex");
 
         match num {
             1 => ChainId::Mainnet,
@@ -126,7 +126,7 @@ impl DidUrl {
             None
         };
 
-        path.next().map(|p| parse_ethr_did(p).ok()).flatten();
+        path.next().and_then(|p| parse_ethr_did(p).ok());
 
         Ok(Self {
             url,
@@ -276,7 +276,7 @@ impl<'de> Deserialize<'de> for DidUrl {
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        DidUrl::parse(&s).map_err(serde::de::Error::custom)
+        DidUrl::parse(s).map_err(serde::de::Error::custom)
     }
 }
 

--- a/src/types/ethr.rs
+++ b/src/types/ethr.rs
@@ -91,7 +91,7 @@ impl EthrBuilder {
     /// Set the controller of the document
     pub fn controller(&mut self, controller: &Address) -> Result<()> {
         let mut did = self.id.clone();
-        did.set_path(&format!("ethr:0x{}", hex::encode(&controller)))?;
+        did.set_path(&format!("ethr:0x{}", hex::encode(controller)))?;
         self.controller = Some(did);
         Ok(())
     }
@@ -108,7 +108,7 @@ impl EthrBuilder {
         }
 
         let delegate_type = String::from_utf8_lossy(&event.delegate_type);
-        let key_purpose = types::parse_delegate(&delegate_type.to_string());
+        let key_purpose = types::parse_delegate(delegate_type.as_ref());
         match key_purpose {
             Ok(KeyPurpose::SignatureAuthentication) => {
                 self.delegate(&event.delegate, KeyPurpose::SignatureAuthentication);


### PR DESCRIPTION
If clippy finds some improvements to make to the code, the docker build will still succeed. This PR makes the docker build fail on clippy warnings. I think clippy suggestions are still useful as a tool, especially as the team ramps up on rust use so it makes sense to fail the build on PRs where clippy has suggestions