### PR TITLE
fix DIDRegistry.json for dependant crates, `lib/abi -> abi`

### DIFF
--- a/lib/src/resolver/did_registry.rs
+++ b/lib/src/resolver/did_registry.rs
@@ -15,7 +15,7 @@ pub use self::did_registry::*;
 
 abigen!(
     DIDRegistry,
-    "./lib/abi/DIDRegistry.json",
+    "./abi/DIDRegistry.json",
     derives(serde::Serialize, serde::Deserialize)
 );
 


### PR DESCRIPTION
When compiling `lib-didethresolver` with `xps-gateway`, the gateway compile is unable to find `DIDRegistry.json`, but `lib-didethresolver` still compiles successfully in it's own directory

during compilation, `cargo` auto-sets the directory to `$CARGO_MANIFEST_DIR`, which for lib-didethresolver is this:

 cat target/debug/build/lib-didethresolver-7a76cec61a699ce9/output
   1   │ /Users/insipx/.cargo/git/checkouts/didethresolver-52eccfd11c9d11f4/998b9f5/lib
   2   │ /Users/insipx/.cargo/git/checkouts/didethresolver-52eccfd11c9d11f4/998b9f5/lib/lib/abi/DIDRegistry.json

when compiling on its own, `CARGO_MANIFEST_DIR` is probably set to the virtual manifest rather than the one in `lib`, causing this error

debugged using this `build.rs`
```rust
fn main() {
    let manifest_dir = env!("CARGO_MANIFEST_DIR");
    println!("{}", manifest_dir);
    println!("{}/lib/abi/DIDRegistry.json", manifest_dir);
}
```

we were adding an extra `lib`, this pr solves the issue and enables a successful compile for both crates