### PR TITLE
34: replace url crate with peg parser based on RFC 3986

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,44 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'didethresolver'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                ],
+                "filter": {
+                    "name": "lib-didethresolver",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'resolver'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=resolver",
+                    "--package=resolver"
+                ],
+                "filter": {
+                    "name": "resolver",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,7 +2587,6 @@ dependencies = [
  "smart-default",
  "surf",
  "thiserror",
- "tiny-keccak",
  "tokio",
  "tokio-test",
  "tracing",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,7 +38,6 @@ smart-default = "0.7"
 sha3 = "0.10"
 peg = "0.8"
 rustc-hex = "2.1"
-tiny-keccak = { version = "2.0.2", default-features = false }
 
 [dev-dependencies]
 tracing-subscriber.workspace = true 

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -23,8 +23,6 @@ pub enum ResolverError<M: Middleware> {
 pub enum DidError {
     #[error("Parsing of ethr:did failed, {0}")]
     Parse(#[from] peg::error::ParseError<peg::str::LineCol>),
-    #[error(transparent)]
-    Url(#[from] url::ParseError),
 }
 
 /// Errors originating during the construction of a ethr:did document [`EthrBuilder`](crate::types::EthrBuilder)

--- a/lib/src/resolver.rs
+++ b/lib/src/resolver.rs
@@ -128,7 +128,7 @@ impl<M: Middleware + 'static> Resolver<M> {
         history: Vec<(DIDRegistryEvents, LogMeta)>,
     ) -> Result<DidResolutionResult, ResolverError<M>> {
         let mut base_document = DidDocument::ethr_builder();
-        base_document.public_key(&public_key)?;
+        base_document.account_address(&public_key)?;
 
         let current_block = self
             .signer

--- a/lib/src/resolver/did_registry.rs
+++ b/lib/src/resolver/did_registry.rs
@@ -8,8 +8,8 @@ use ethers::{
     providers::Middleware,
     signers::{LocalWallet, Signer},
     types::{Signature, H256, U256, U64},
+    utils::keccak256,
 };
-use tiny_keccak::{Hasher, Keccak};
 
 pub use self::did_registry::*;
 
@@ -226,19 +226,6 @@ async fn sign_typed_data<M: Middleware>(
 
     let signature = wallet.sign_hash(hash)?;
     Ok(signature)
-}
-
-/// Compute the Keccak-256 hash of input bytes.
-///
-/// Note that strings are interpreted as UTF-8 bytes,
-pub fn keccak256<T: AsRef<[u8]>>(bytes: T) -> [u8; 32] {
-    let mut output = [0u8; 32];
-
-    let mut hasher = Keccak::v256();
-    hasher.update(bytes.as_ref());
-    hasher.finalize(&mut output);
-
-    output
 }
 
 #[cfg(test)]

--- a/lib/src/types/did_parser.rs
+++ b/lib/src/types/did_parser.rs
@@ -7,16 +7,41 @@ use crate::types::*;
 pub use did_ethr_attribute_parser::attribute as parse_attribute;
 pub use did_ethr_delegate_parser::delegate as parse_delegate;
 pub use did_ethr_parser::ethr_did as parse_ethr_did;
+pub use did_ethr_parser::ethr_did_url as parse_ethr_did_url;
 
 peg::parser! {
     grammar did_ethr_parser() for str {
+        /// parses the `did` with a url path part of a [DID-URL](https://www.w3.org/TR/did-core/#did-syntax)
+        /// # Example
+        /// ```rust
+        /// use lib_didethresolver::types::{DidUrl, Did, Method, Network, Account, parse_ethr_did_url};
+        /// use ethers::types::Address;
+        /// let parsed = parse_ethr_did_url("did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a/abc").unwrap();
+        /// assert_eq!(
+        ///   parsed,
+        ///  DidUrl {
+        ///     did: Did {
+        ///        method: Method::Ethr,
+        ///        network: Network::Mainnet,
+        ///       account: Account::Address(Address::from_slice(
+        ///       &hex::decode("b9c5714089478a327f09197987f16f9e5d936e8a").unwrap())),
+        ///     },
+        ///     path: Some("/abc".to_string()),
+        ///     query: None,
+        ///     fragment: None
+        ///  });
+        /// ```
+        ///
+        pub rule ethr_did_url() -> DidUrl
+            = did:ethr_did() path:did_path() query:did_query() fragment:did_fragment() { DidUrl { did, path, query, fragment } }
+
         /// parses the `did` part of a [DID-URL](https://www.w3.org/TR/did-core/#did-syntax)
         ///
         /// # Example
         /// ```rust
         /// use lib_didethresolver::types::{Did, Method, Network, Account, parse_ethr_did};
         /// use ethers::types::Address;
-        /// let parsed = parse_ethr_did("ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a").unwrap();
+        /// let parsed = parse_ethr_did("did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a").unwrap();
         /// assert_eq!(
         ///    parsed,
         ///    Did {
@@ -28,30 +53,94 @@ peg::parser! {
         ///   });
         /// ```
         pub rule ethr_did() -> Did
-            = method:method() ":" network:network()? account:account() { Did { method, network: network.unwrap_or_default(), account } }
+            = did() ":" method:method() ":" network:(chain_id() / network())? account:account() { Did { method, network: network.unwrap_or_default(), account } }
+
+        rule did() = "did" / expected!("only `did` is supported")
 
         rule method() -> Method
             = "ethr" { Method::Ethr } / expected!("the only supported method is `ethr`")
 
+        rule chain_id() -> Network
+            = "0" i("x") digits:$(HEXDIG()+) ":" { Network::from(digits) }
+
         rule network() -> Network
             // chain id networks
-            = "0" i("x") digits:$(hex_digit()+) ":" { Network::from(digits) }
-            // named networks
-            / "mainnet:" { Network::Mainnet }
+            = // named networks
+            "mainnet:" { Network::Mainnet }
             / "sepolia:" { Network::Sepolia }
-            / expected!("the only supported networks are `mainnet`, `sepolia`, and chain id")
+            / expected!("the only supported networks are `mainnet`, `sepolia`")
 
         rule account() -> Account
-            = "0" i("x") digits:$(hex_digit()*<40>) { Account::Address(Address::from_slice(&hex::decode(digits).unwrap())) }
-            / "0" i("x") digits:$(hex_digit()*<66>) { Account::HexKey(hex::decode(digits).unwrap()) }
-
-        rule hex_digit() -> String
-           = digits:$(['0'..='9' | 'a'..='f' | 'A'..='F']) { digits.to_string() }
+            = "0" i("x") digits:$(HEXDIG()*<40>) { Account::Address(Address::from_slice(&hex::decode(digits).unwrap())) }
+            / "0" i("x") digits:$(HEXDIG()*<66>) { Account::HexKey(hex::decode(digits).unwrap()) }
 
         // case insensitive rule (see https://github.com/kevinmehall/rust-peg/issues/216)
         rule i(literal: &'static str)
             = input:$([_]*<{literal.len()}>)
             {? if input.eq_ignore_ascii_case(literal) { Ok(()) } else { Err(literal) } }
+
+        // parses a url path according to the RFC 3986 definition
+        // https://www.rfc-editor.org/rfc/rfc3986#section-3.3
+
+        rule did_path() -> Option<String> = path:$(path_rootless() / path_abempty() / path_absolute() / path_noscheme() / path_empty()) (&"?" / ![_])?
+            { if path.is_empty() { None } else { Some(path.to_string()) } }
+
+        rule path_abempty() = ( "/" segment() )*
+
+        rule path_absolute() = "/" ( segment_nz() ( "/" segment() )* )+
+
+        rule path_rootless() = segment_nz() ( "/" segment() )*
+
+        rule path_noscheme() = segment_nz_nc() ( "/" segment() )*
+
+        rule segment() = pchar()*
+
+        rule segment_nz() = pchar()+
+
+        rule segment_nz_nc() = ( unreserved() / pct_encoded() / sub_delims() / "@" )+
+
+        rule pchar() = unreserved() / pct_encoded() / sub_delims() / ":" / "@"
+
+        rule unreserved() = ALPHA() / DIGIT() / "-" / "." / "_" / "~"
+
+        rule pct_encoded() = "%" HEXDIG() HEXDIG()
+
+        rule sub_delims() = "!" / "$" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "=" / "&"
+
+        rule path_empty() = ""
+
+        rule qchar() = unreserved() / pct_encoded() / ":" / "@" / "/" / "?"
+
+        rule ALPHA() -> char
+            = ['a'..='z' | 'A'..='Z']
+
+        rule DIGIT() -> char
+            = ['0'..='9']
+
+        rule HEXDIG() -> char
+            = ['0'..='9' | 'a'..='f' | 'A'..='F']
+
+        // parses a query according to the RFC 3986 definition
+        // https://www.rfc-editor.org/rfc/rfc3986#section-3.4
+        rule did_query() -> Option<Vec<(String, String)>> = query()?
+
+        rule query() -> Vec<(String, String)> = "?" q:query_assignment() ** "&" (&"#" / ![_]) { q }
+
+        rule query_assignment() -> (String, String) = n:$(query_name()) "=" v:$(query_value()) { (n.to_string(), v.to_string()) }
+
+        rule query_name() = qchar()+
+
+        rule query_value() = qchar()*
+
+        // parses a fragment according to the RFC 3986 definition
+        // https://www.rfc-editor.org/rfc/rfc3986#section-3.5
+        rule did_fragment() -> Option<String> = fragment:$(fragment()?)
+            {
+                let fragment = fragment.strip_prefix('#').unwrap_or("");
+                if fragment.is_empty() { None } else { Some(fragment.to_string()) }
+            }
+
+        rule fragment() = "#" ( pchar() / "/" / "?" )* ![_]
     }
 }
 
@@ -242,9 +331,17 @@ mod tests {
     }
 
     #[test]
+    fn test_did_ethr_is_required() {
+        let parsed = parse_ethr_did("did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a");
+        assert!(parsed.is_ok());
+        let parsed = parse_ethr_did("ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a");
+        assert!(parsed.is_err());
+    }
+
+    #[test]
     fn test_ethr_method_parser() {
         let parsed =
-            parse_ethr_did("ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a").unwrap();
+            parse_ethr_did("did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a").unwrap();
         assert_eq!(
             parsed,
             Did {
@@ -257,7 +354,7 @@ mod tests {
         );
 
         // Mainnet is default
-        let parsed = parse_ethr_did("ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a").unwrap();
+        let parsed = parse_ethr_did("did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a").unwrap();
         assert_eq!(
             parsed,
             Did {
@@ -270,7 +367,7 @@ mod tests {
         );
 
         let parsed =
-            parse_ethr_did("ethr:0x01:0xb9c5714089478a327f09197987f16f9e5d936e8a").unwrap();
+            parse_ethr_did("did:ethr:0x01:0xb9c5714089478a327f09197987f16f9e5d936e8a").unwrap();
         assert_eq!(
             parsed,
             Did {
@@ -301,6 +398,249 @@ mod tests {
         assert_eq!(
             parsed.to_string(),
             "error at 1:1: expected the only supported delegate types are `sigAuth` and `veriKey`"
+        );
+    }
+
+    #[test]
+    fn test_ethr_did_parse_url() {
+        let parsed = parse_ethr_did_url(
+            "did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a/location/1/2:/3",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            DidUrl {
+                did: Did {
+                    method: Method::Ethr,
+                    network: Network::Mainnet,
+                    account: Account::Address(Address::from_slice(
+                        &hex::decode("b9c5714089478a327f09197987f16f9e5d936e8a").unwrap()
+                    ))
+                },
+                path: Some("/location/1/2:/3".to_string()),
+                query: None,
+                fragment: None
+            }
+        );
+    }
+
+    #[test]
+    fn test_ethr_did_parse_url_1() {
+        let parsed =
+            parse_ethr_did_url("did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a/")
+                .unwrap();
+        assert_eq!(
+            parsed,
+            DidUrl {
+                did: Did {
+                    method: Method::Ethr,
+                    network: Network::Mainnet,
+                    account: Account::Address(Address::from_slice(
+                        &hex::decode("b9c5714089478a327f09197987f16f9e5d936e8a").unwrap()
+                    ))
+                },
+                path: Some("/".to_string()),
+                query: None,
+                fragment: None
+            }
+        );
+    }
+
+    #[test]
+    fn test_ethr_did_parse_url_empty_path() {
+        let parsed =
+            parse_ethr_did_url("did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+                .unwrap();
+        assert_eq!(
+            parsed,
+            DidUrl {
+                did: Did {
+                    method: Method::Ethr,
+                    network: Network::Mainnet,
+                    account: Account::Address(Address::from_slice(
+                        &hex::decode("b9c5714089478a327f09197987f16f9e5d936e8a").unwrap()
+                    ))
+                },
+                path: None,
+                query: None,
+                fragment: None
+            }
+        );
+    }
+
+    #[test]
+    fn test_ethr_did_parse_url_query() {
+        let parsed = parse_ethr_did_url(
+            "did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a?a=????&c=d",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            DidUrl {
+                did: Did {
+                    method: Method::Ethr,
+                    network: Network::Mainnet,
+                    account: Account::Address(Address::from_slice(
+                        &hex::decode("b9c5714089478a327f09197987f16f9e5d936e8a").unwrap()
+                    ))
+                },
+                path: None,
+                query: Some(vec![
+                    ("a".to_string(), "????".to_string()),
+                    ("c".to_string(), "d".to_string())
+                ]),
+                fragment: None
+            }
+        );
+    }
+
+    #[test]
+    fn test_ethr_did_parse_url_fragment() {
+        let parsed = parse_ethr_did_url(
+            "did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a#section3_5",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            DidUrl {
+                did: Did {
+                    method: Method::Ethr,
+                    network: Network::Mainnet,
+                    account: Account::Address(Address::from_slice(
+                        &hex::decode("b9c5714089478a327f09197987f16f9e5d936e8a").unwrap()
+                    ))
+                },
+                path: None,
+                query: None,
+                fragment: Some("section3_5".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn test_ethr_did_parse_url_path_query() {
+        let parsed = parse_ethr_did_url(
+            "did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a/:1/:2/:3/?a=b&c=d",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            DidUrl {
+                did: Did {
+                    method: Method::Ethr,
+                    network: Network::Mainnet,
+                    account: Account::Address(Address::from_slice(
+                        &hex::decode("b9c5714089478a327f09197987f16f9e5d936e8a").unwrap()
+                    ))
+                },
+                path: Some("/:1/:2/:3/".to_string()),
+                query: Some(vec![
+                    ("a".to_string(), "b".to_string()),
+                    ("c".to_string(), "d".to_string())
+                ]),
+                fragment: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_ethr_did_parse_url_path_fragment() {
+        let parsed = parse_ethr_did_url(
+            "did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a/a/b/c#section3_5",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            DidUrl {
+                did: Did {
+                    method: Method::Ethr,
+                    network: Network::Mainnet,
+                    account: Account::Address(Address::from_slice(
+                        &hex::decode("b9c5714089478a327f09197987f16f9e5d936e8a").unwrap()
+                    ))
+                },
+                path: Some("/a/b/c".to_string()),
+                query: None,
+                fragment: Some("section3_5".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn test_ethr_did_parse_url_query_fragment() {
+        let parsed = parse_ethr_did_url(
+            "did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a?a=b&c=d#section3_5",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            DidUrl {
+                did: Did {
+                    method: Method::Ethr,
+                    network: Network::Mainnet,
+                    account: Account::Address(Address::from_slice(
+                        &hex::decode("b9c5714089478a327f09197987f16f9e5d936e8a").unwrap()
+                    ))
+                },
+                path: None,
+                query: Some(vec![
+                    ("a".to_string(), "b".to_string()),
+                    ("c".to_string(), "d".to_string())
+                ]),
+                fragment: Some("section3_5".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn test_ethr_did_parse_url_path_query_fragment() {
+        let parsed = parse_ethr_did_url(
+            "did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a/a/b/c?x=y&z1=#section3_5",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            DidUrl {
+                did: Did {
+                    method: Method::Ethr,
+                    network: Network::Mainnet,
+                    account: Account::Address(Address::from_slice(
+                        &hex::decode("b9c5714089478a327f09197987f16f9e5d936e8a").unwrap()
+                    ))
+                },
+                path: Some("/a/b/c".to_string()),
+                query: Some(vec![
+                    ("x".to_string(), "y".to_string()),
+                    ("z1".to_string(), "".to_string())
+                ]),
+                fragment: Some("section3_5".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn test_ethr_did_parse_url_query_chars() {
+        let parsed = parse_ethr_did_url(
+            "did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a?a=b&c=d:/?@",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            DidUrl {
+                did: Did {
+                    method: Method::Ethr,
+                    network: Network::Mainnet,
+                    account: Account::Address(Address::from_slice(
+                        &hex::decode("b9c5714089478a327f09197987f16f9e5d936e8a").unwrap(),
+                    ))
+                },
+                path: None,
+                query: Some(vec![
+                    ("a".to_string(), "b".to_string()),
+                    ("c".to_string(), "d:/?@".to_string())
+                ]),
+                fragment: None
+            }
         );
     }
 }

--- a/lib/src/types/ethr.rs
+++ b/lib/src/types/ethr.rs
@@ -117,7 +117,7 @@ impl EthrBuilder {
 
     /// set the identity of the document
     pub fn public_key(&mut self, key: &Address) -> Result<(), EthrBuilderError> {
-        self.id.set_account(types::Account::Address(*key));
+        self.id = self.id.with_account(types::Account::Address(*key));
         Ok(())
     }
 
@@ -128,8 +128,7 @@ impl EthrBuilder {
 
     /// Set the controller of the document
     pub fn controller(&mut self, controller: &Address) -> Result<(), EthrBuilderError> {
-        let mut did = self.id.clone();
-        did.set_account(types::Account::Address(*controller));
+        let did = self.id.with_account(types::Account::Address(*controller));
         self.controller = Some(did);
         Ok(())
     }
@@ -254,8 +253,7 @@ impl EthrBuilder {
         value: V,
         service: ServiceType,
     ) -> Result<(), EthrBuilderError> {
-        let mut did = self.id.clone();
-        did.set_fragment(Some(&format!("service-{}", index)));
+        let did = self.id.with_fragment(Some(&format!("service-{}", index)));
         let endpoint = Url::parse(&String::from_utf8_lossy(value.as_ref()))?;
         self.service.push(Service {
             id: did,
@@ -280,9 +278,7 @@ impl EthrBuilder {
         value: V,
         key: PublicKey,
     ) -> Result<(), EthrBuilderError> {
-        let mut did = self.id.clone();
-        did.set_fragment(Some(&format!("delegate-{}", index)));
-
+        let did = self.id.with_fragment(Some(&format!("delegate-{}", index)));
         let method = VerificationMethod {
             id: did,
             controller: self.id.clone(),
@@ -332,8 +328,7 @@ impl EthrBuilder {
     ///
     /// reference: [spec](https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md)
     pub fn delegate(&mut self, index: usize, delegate: &Address, purpose: KeyPurpose) {
-        let mut did = self.id.clone();
-        did.set_fragment(Some(&format!("delegate-{}", index)));
+        let did = self.id.with_fragment(Some(&format!("delegate-{}", index)));
 
         // TODO: Handle ChainID
         let method = VerificationMethod {
@@ -360,7 +355,7 @@ impl EthrBuilder {
     /// Handle controller changes according to [owner changed](https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md#controller-changes-didownerchanged) and [registration](https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md#create-register)
     fn build_controller(&mut self) {
         let mut controller = self.controller.clone().unwrap_or(self.id.clone());
-        controller.set_fragment(Some("controller"));
+        controller = controller.with_fragment(Some("controller"));
 
         self.verification_method.push(VerificationMethod {
             id: controller.clone(),
@@ -374,8 +369,7 @@ impl EthrBuilder {
         // if we are resolving for a key that is a public key which matches the id, we need to add
         // another `controllerKey` verification method
         if let Account::HexKey(_) = self.id.account() {
-            let mut controller_key = self.id.clone();
-            controller_key.set_fragment(Some("controllerKey"));
+            let controller_key = self.id.with_fragment(Some("controllerKey"));
             self.verification_method.push(VerificationMethod {
                 id: controller_key.clone(),
                 controller: self.id.clone(),

--- a/lib/src/types/ethr.rs
+++ b/lib/src/types/ethr.rs
@@ -5,7 +5,7 @@
 //! # Examples
 //!
 //! let mut builder = EthrBuilder::default();
-//! builder.public_key(&Address::from_str("0x872A62ABAfa278F0E0f02c1C5042D0614c3f38eb")).unwrap();
+//! builder.account_address(&Address::from_str("0x872A62ABAfa278F0E0f02c1C5042D0614c3f38eb")).unwrap();
 //! let document = builder.build();
 
 use std::{collections::HashMap, str::FromStr};
@@ -116,8 +116,14 @@ impl EthrBuilder {
     }
 
     /// set the identity of the document
-    pub fn public_key(&mut self, key: &Address) -> Result<(), EthrBuilderError> {
+    pub fn account_address(&mut self, key: &Address) -> Result<(), EthrBuilderError> {
         self.id = self.id.with_account(types::Account::Address(*key));
+        Ok(())
+    }
+
+    /// set the identity of the document
+    pub fn public_key(&mut self, key: &[u8]) -> Result<(), EthrBuilderError> {
+        self.id = self.id.with_account(types::Account::HexKey(key.to_vec()));
         Ok(())
     }
 
@@ -465,7 +471,7 @@ pub(crate) mod tests {
         };
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::zero());
         builder.attribute_event(event).unwrap();
         let doc = builder.build().unwrap();
@@ -484,17 +490,18 @@ pub(crate) mod tests {
             }
         )
     }
+
     #[test]
     fn test_attribute_changed_ed25519() {
         let identity = address("0x7e575682a8e450e33eb0493f9972821ae333cd7f");
         let event = DidattributeChangedFilter {
-            name: *b"did/pub/Secp256k1/veriKey/base58",
+            name: *b"did/pub/Ed25519/veriKey/base58  ",
             value: b"b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71".into(),
             ..base_attr_changed(identity, None)
         };
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::zero());
         builder.attribute_event(event).unwrap();
         let doc = builder.build().unwrap();
@@ -503,7 +510,7 @@ pub(crate) mod tests {
             VerificationMethod {
                 id: DidUrl::parse("did:ethr:0x7e575682a8e450e33eb0493f9972821ae333cd7f#delegate-0")
                     .unwrap(),
-                verification_type: KeyType::EcdsaSecp256k1VerificationKey2019,
+                verification_type: KeyType::Ed25519VerificationKey2020,
                 controller: DidUrl::parse("did:ethr:0x7e575682a8e450e33eb0493f9972821ae333cd7f")
                     .unwrap(),
                 verification_properties: Some(VerificationMethodProperties::PublicKeyBase58 {
@@ -523,7 +530,7 @@ pub(crate) mod tests {
         };
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::zero());
         builder.attribute_event(event).unwrap();
         let doc = builder.build().unwrap();
@@ -553,7 +560,7 @@ pub(crate) mod tests {
         };
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::zero());
         builder.attribute_event(event).unwrap();
         let doc = builder.build().unwrap();
@@ -601,7 +608,7 @@ pub(crate) mod tests {
         ];
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::zero());
 
         for event in events {
@@ -657,7 +664,7 @@ pub(crate) mod tests {
         ];
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::from(100));
         for event in events {
             builder.attribute_event(event).unwrap();
@@ -685,7 +692,7 @@ pub(crate) mod tests {
         };
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::zero());
         builder.owner_event(event).unwrap();
 
@@ -716,7 +723,7 @@ pub(crate) mod tests {
         ];
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::zero());
         for event in events {
             builder.delegate_event(event).unwrap();
@@ -792,7 +799,7 @@ pub(crate) mod tests {
         ];
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::zero());
         for event in &events {
             builder.delegate_event(event.clone()).unwrap();
@@ -802,7 +809,7 @@ pub(crate) mod tests {
         assert_eq!(builder.keys.len(), 2);
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::from(75));
         for event in &events {
             builder.delegate_event(event.clone()).unwrap();
@@ -811,7 +818,7 @@ pub(crate) mod tests {
         assert_eq!(builder.keys.len(), 1);
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::from(125));
         for event in &events {
             builder.delegate_event(event.clone()).unwrap();
@@ -854,7 +861,7 @@ pub(crate) mod tests {
         ];
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::zero());
 
         builder.attribute_event(attributes[0].clone()).unwrap();
@@ -899,7 +906,7 @@ pub(crate) mod tests {
         ];
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::zero());
         for event in events {
             builder.owner_event(event).unwrap();
@@ -930,7 +937,7 @@ pub(crate) mod tests {
         };
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::zero());
 
         builder.attribute_event(event).unwrap();

--- a/lib/src/types/xmtp.rs
+++ b/lib/src/types/xmtp.rs
@@ -78,19 +78,17 @@ impl EthrBuilder {
         value: V,
         key: XmtpAttribute,
     ) -> Result<(), EthrBuilderError> {
-        let mut did = self.id.clone();
-        did.set_fragment(Some(&format!("xmtp-{}", index)));
-
         log::debug!("index: {}", index);
-        let mut method = VerificationMethod {
-            id: did,
+        let did_url = self
+            .id
+            .with_fragment(Some(&format!("xmtp-{}", index)))
+            .with_query("meta", Some(&key.purpose.to_string()));
+        let method = VerificationMethod {
+            id: did_url,
             controller: self.id.clone(),
             verification_type: KeyType::Ed25519VerificationKey2020,
             verification_properties: Self::encode_attribute_value(value, key.encoding)?,
         };
-
-        method.id.set_query("meta", Some(&key.purpose.to_string()));
-
         match key.purpose {
             XmtpKeyPurpose::Installation => {
                 self.authentication.push(method.id.clone());
@@ -134,7 +132,7 @@ mod test {
         assert_eq!(doc.verification_method[1].id.fragment().unwrap(), "xmtp-0");
         assert_eq!(
             doc.verification_method[1].id.query().unwrap(),
-            "meta=installation"
+            vec![("meta".to_string(), "installation".to_string())]
         );
         assert_eq!(doc.verification_method.len(), 2);
 

--- a/lib/src/types/xmtp.rs
+++ b/lib/src/types/xmtp.rs
@@ -120,7 +120,7 @@ mod test {
         }];
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::zero());
 
         for attr in attributes {
@@ -149,7 +149,7 @@ mod test {
         }];
 
         let mut builder = EthrBuilder::default();
-        builder.public_key(&identity).unwrap();
+        builder.account_address(&identity).unwrap();
         builder.now(U256::from(100));
 
         for attr in attributes {

--- a/resolver/src/argenv.rs
+++ b/resolver/src/argenv.rs
@@ -100,10 +100,16 @@ mod tests {
         assert_eq!(args.port, DEFAULT_PORT);
         assert_eq!(args.rpc_url, DEFAULT_RPC_URL);
         assert_eq!(args.did_registry, "0x1234567890");
-        let args2 = Args::parse_from(&["didethresolver", "--did-registry", "0x0987654321"]);
+        let args2 = Args::parse_from(&[
+            "didethresolver",
+            "--did-registry",
+            "0x0987654321",
+            "--rpc-url",
+            "http://rpc2.xyz",
+        ]);
         assert_eq!(args2.host, DEFAULT_HOST);
         assert_eq!(args2.port, DEFAULT_PORT);
-        assert_eq!(args2.rpc_url, DEFAULT_RPC_URL);
+        assert_eq!(args2.rpc_url, "http://rpc2.xyz");
         assert_eq!(args2.did_registry, "0x0987654321");
         putback(env)
     }


### PR DESCRIPTION
closes #34 

- adding path + query + fragment
- test coveragee
- parses query as a vec of string tuple

general cleanup, make DidUrl immutable by removing setter

fix rustdoc